### PR TITLE
module: support go 1.20+

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module tinygo.org/x/tinygl-font
 
-go 1.22.0
+go 1.20
 
 require (
 	golang.org/x/image v0.15.0


### PR DESCRIPTION
This corrects the minimal supported Go version to 1.20+

It was not intentional when creating this package, just an artifact of what version I was running at the time.

Needed to correct minimum version for tinygl itself.